### PR TITLE
feat: minimum GKE infrastructure

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+<!-- 
+Thank you for contributing to ImpulsaEdu! 
+
+Please fill out all sections below to ensure a smooth review process.
+Delete any sections that don't apply to your PR.
+-->
+
+## Issue Reference
+
+Closes #<!-- Add the issue number here -->
+
+## Description
+
+<!-- Provide a brief summary of the changes you made -->
+
+## Success Criteria Met
+
+<!-- List the success criteria from the issue and confirm they are met -->
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Testing
+
+<!-- Describe how you tested your changes -->
+
+- [ ] Unit tests added/updated
+- [ ] Manual testing completed
+- [ ] Tested on different browsers/environments (if applicable)
+
+## Screenshots/Videos (if applicable)
+
+<!-- Add any relevant screenshots or videos demonstrating your changes -->
+
+## Related Changes
+
+<!-- Link any related PRs or issues -->
+
+## Checklist
+
+- [ ] Code follows project conventions
+- [ ] All tests pass
+- [ ] Commits have clear, meaningful messages
+- [ ] No unrelated changes included
+- [ ] Documentation updated (if needed)
+
+## Additional Notes
+
+<!-- Any additional context or notes for the reviewer -->

--- a/.github/workflows/deploy-gke.yml
+++ b/.github/workflows/deploy-gke.yml
@@ -1,0 +1,141 @@
+name: Deploy to GKE
+
+on:
+  push:
+    branches:
+      - main       # → impulsa-prod
+      - develop    # → impulsa-dev
+
+env:
+  GCP_PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  GKE_CLUSTER: ${{ secrets.GKE_CLUSTER }}
+  GKE_REGION: ${{ secrets.GKE_REGION }}
+  REGISTRY: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/impulsa
+
+jobs:
+  # ──────────────────────────────────────────────
+  # 1. Build & push images to Artifact Registry
+  # ──────────────────────────────────────────────
+  build:
+    name: Build & Push Images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write   # Required for Workload Identity Federation
+
+    outputs:
+      image_tag: ${{ steps.meta.outputs.tag }}
+      overlay: ${{ steps.env.outputs.overlay }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Determine overlay
+        id: env
+        run: |
+          if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+            echo "overlay=prod" >> "$GITHUB_OUTPUT"
+          else
+            echo "overlay=dev" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Authenticate to GCP via Workload Identity
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev --quiet
+
+      - name: Compute image tag
+        id: meta
+        run: echo "tag=${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push frontend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./frontend
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/impulsa-frontend:${{ steps.meta.outputs.tag }}
+            ${{ env.REGISTRY }}/impulsa-frontend:${{ steps.env.outputs.overlay == 'prod' && 'latest' || 'dev' }}
+
+      - name: Build & push api-service
+        uses: docker/build-push-action@v5
+        with:
+          context: ./api-service
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/impulsa-api:${{ steps.meta.outputs.tag }}
+            ${{ env.REGISTRY }}/impulsa-api:${{ steps.env.outputs.overlay == 'prod' && 'latest' || 'dev' }}
+
+      - name: Build & push auth-service
+        uses: docker/build-push-action@v5
+        with:
+          context: ./auth-service
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/impulsa-auth:${{ steps.meta.outputs.tag }}
+            ${{ env.REGISTRY }}/impulsa-auth:${{ steps.env.outputs.overlay == 'prod' && 'latest' || 'dev' }}
+
+  # ──────────────────────────────────────────────
+  # 2. Deploy to GKE with kustomize
+  # ──────────────────────────────────────────────
+  deploy:
+    name: Deploy to GKE (${{ needs.build.outputs.overlay }})
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP via Workload Identity
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: ${{ secrets.GKE_CLUSTER }}
+          location: ${{ secrets.GKE_REGION }}
+
+      - name: Set up Kustomize
+        run: |
+          curl -sfL https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv5.3.0/kustomize_v5.3.0_linux_amd64.tar.gz \
+            | tar xz && sudo mv kustomize /usr/local/bin/
+
+      - name: Pin image tags in kustomize overlay
+        run: |
+          OVERLAY=${{ needs.build.outputs.overlay }}
+          TAG=${{ needs.build.outputs.image_tag }}
+          cd k8s/overlays/$OVERLAY
+          kustomize edit set image \
+            REGISTRY/impulsa-frontend=${{ env.REGISTRY }}/impulsa-frontend:$TAG \
+            REGISTRY/impulsa-api=${{ env.REGISTRY }}/impulsa-api:$TAG \
+            REGISTRY/impulsa-auth=${{ env.REGISTRY }}/impulsa-auth:$TAG
+
+      - name: Apply manifests
+        run: |
+          OVERLAY=${{ needs.build.outputs.overlay }}
+          kustomize build k8s/overlays/$OVERLAY | kubectl apply -f -
+
+      - name: Wait for rollout
+        run: |
+          NAMESPACE=impulsa-${{ needs.build.outputs.overlay }}
+          kubectl rollout status deployment/frontend    -n $NAMESPACE --timeout=120s
+          kubectl rollout status deployment/api-service  -n $NAMESPACE --timeout=120s
+          kubectl rollout status deployment/auth-service -n $NAMESPACE --timeout=120s

--- a/docs/architecture/gke-infrastructure.md
+++ b/docs/architecture/gke-infrastructure.md
@@ -1,0 +1,220 @@
+# GKE Infrastructure – ImpulsaEdu
+
+## Architecture Overview
+
+```
+Internet
+   │
+   ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                        GKE Cluster                                  │
+│                                                                     │
+│  ┌───────────────────────────────────────────────────────────────┐  │
+│  │  NGINX Ingress + GKE Managed TLS Certificate                 │  │
+│  └──────────────┬────────────────┬────────────────┬─────────────┘  │
+│                 │/               │/api/*           │/auth/*         │
+│                 ▼                ▼                 ▼                │
+│  ┌──────────────┐  ┌─────────────────┐  ┌──────────────────┐       │
+│  │   frontend   │  │   api-service   │  │   auth-service   │       │
+│  │  (Next.js)   │  │ (Fastify/Node)  │  │  (Fastify/Node)  │       │
+│  │  :3000 ×2   │  │  :8080  ×2     │  │   :8081 ×2      │       │
+│  │  HPA 2→5    │  │  HPA 2→5       │  │                  │       │
+│  └──────────────┘  └────────┬────────┘  └────────┬─────────┘       │
+│                             │                     │                 │
+│                             └──────────┬──────────┘                 │
+│                                        ▼                            │
+│                             ┌─────────────────┐                     │
+│                             │    postgres      │  (or Cloud SQL)    │
+│                             │  :5432 ×1       │                     │
+│                             │  StatefulSet     │                     │
+│                             │  PVC 10Gi        │                     │
+│                             └─────────────────┘                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Namespaces
+
+| Namespace | Branch | Purpose |
+|---|---|---|
+| `impulsa-dev` | `develop` | Continuous integration deploys |
+| `impulsa-prod` | `main` | Production workloads |
+
+---
+
+## Kubernetes Objects Summary
+
+| Service | Kind | Replicas | HPA |
+|---|---|---|---|
+| `frontend` | Deployment | 2 | 2–5 (CPU 70%) |
+| `api-service` | Deployment | 2 | 2–5 (CPU 70%) |
+| `auth-service` | Deployment | 2 | — |
+| `postgres` | StatefulSet | 1 | — |
+
+---
+
+## Resource Limits
+
+| Service | CPU Request | CPU Limit | Memory Request | Memory Limit |
+|---|---|---|---|---|
+| `frontend` | 100m | 500m | 256Mi | 512Mi |
+| `api-service` | 100m | 500m | 256Mi | 512Mi |
+| `auth-service` | 100m | 300m | 128Mi | 256Mi |
+| `postgres` | 250m | 1000m | 512Mi | 1Gi |
+| **Total (min)** | **550m** | **2300m** | **1152Mi** | **2304Mi** |
+
+---
+
+## Recommended Node Pools
+
+### System Node Pool
+Runs GKE system components (kube-system).
+
+| Parameter | Value |
+|---|---|
+| Machine type | `e2-medium` (2 vCPU, 4 GB) |
+| Nodes | 1 (autoscale 1–2) |
+| Taints | `CriticalAddonsOnly=true:NoSchedule` |
+
+### Workloads Node Pool
+Runs all ImpulsaEdu pods.
+
+| Parameter | Value |
+|---|---|
+| Machine type | `e2-standard-2` (2 vCPU, 8 GB RAM) |
+| Nodes | 2 (autoscale 2–4) |
+| Disk size | 50 GB SSD |
+
+**Why `e2-standard-2`?** The minimum resource requests total ~550m CPU and ~1.2 GB RAM. With 2 nodes × 2 vCPU you get 4 vCPU and 16 GB RAM — enough headroom for HPA scale-out bursts and rolling updates without OOM evictions.
+
+---
+
+## TLS Strategy
+
+- **GKE Managed Certificates** (`networking.gke.io/v1 ManagedCertificate`) automatically provision and renew Let's Encrypt certs for the configured domain.
+- The Ingress annotation `networking.gke.io/managed-certificates: impulsa-cert` binds the cert.
+- NGINX Ingress enforces `ssl-redirect: "true"` — all HTTP traffic is redirected to HTTPS.
+
+---
+
+## Secrets Management
+
+Kubernetes Secrets are **not** stored in this repository. Two options:
+
+### Option A – GCP Secret Manager + External Secrets Operator (recommended for production)
+```bash
+# Store in GCP Secret Manager
+gcloud secrets create impulsa-jwt-secret --data-file=- <<< "your-secret"
+
+# External Secrets Operator syncs them into K8s Secrets automatically
+```
+
+### Option B – kubectl (quickstart)
+```bash
+kubectl create secret generic impulsa-secrets \
+  --from-literal=POSTGRES_USER=impulsa \
+  --from-literal=POSTGRES_PASSWORD=<password> \
+  --from-literal=JWT_SECRET=<jwt-secret> \
+  --from-literal=POSTGRES_HOST=<host-or-cloud-sql-ip> \
+  --namespace=impulsa-prod
+```
+
+The file `k8s/base/secrets.template.yaml` documents the required keys — **never commit a file with real values**.
+
+---
+
+## PostgreSQL: StatefulSet vs Cloud SQL
+
+| | StatefulSet (in-cluster) | Cloud SQL (managed) |
+|---|---|---|
+| Setup time | Included in manifests | ~10 min via GCP console |
+| Backups | Manual or Velero | Automatic |
+| HA / failover | Manual | Automatic |
+| Ops burden | Higher | Lower |
+| **Recommendation** | Dev / quick demo | **Production** |
+
+For production, set `POSTGRES_HOST` in the Secret to the Cloud SQL private IP and remove the `postgres/` manifests from the overlay's `kustomization.yaml`.
+
+---
+
+## CI/CD Pipeline
+
+See [`.github/workflows/deploy-gke.yml`](../.github/workflows/deploy-gke.yml).
+
+### Required GitHub Secrets
+
+| Secret | Description |
+|---|---|
+| `GCP_PROJECT_ID` | GCP project ID |
+| `GCP_REGION` | Region (e.g. `us-central1`) |
+| `GKE_CLUSTER` | GKE cluster name |
+| `GKE_REGION` | GKE cluster region or zone |
+| `GCP_WIF_PROVIDER` | Workload Identity Federation provider resource name |
+| `GCP_SERVICE_ACCOUNT` | Service account email for CI/CD |
+
+### Flow
+
+```
+push → develop                    push → main
+       │                                 │
+       ▼                                 ▼
+  Build images                    Build images
+  Push :dev tag                   Push :latest + :SHA
+       │                                 │
+       ▼                                 ▼
+  kustomize build                 kustomize build
+  overlays/dev                    overlays/prod
+       │                                 │
+       ▼                                 ▼
+  kubectl apply                   kubectl apply
+  (impulsa-dev)                   (impulsa-prod)
+```
+
+---
+
+## Health & Readiness Probes
+
+All services expose a `GET /health` endpoint (returning HTTP 200) used by both probes.
+
+| Service | Liveness | Readiness |
+|---|---|---|
+| `frontend` | `GET /api/health` | `GET /api/health` |
+| `api-service` | `GET /health` | `GET /health` |
+| `auth-service` | `GET /health` | `GET /health` |
+| `postgres` | `pg_isready` exec | `pg_isready` exec |
+
+---
+
+## Directory Structure
+
+```
+k8s/
+├── base/
+│   ├── kustomization.yaml
+│   ├── namespace.yaml
+│   ├── configmap.yaml
+│   ├── secrets.template.yaml       ← template only, no real values
+│   ├── frontend/
+│   │   ├── deployment.yaml
+│   │   ├── service.yaml
+│   │   └── hpa.yaml
+│   ├── api-service/
+│   │   ├── deployment.yaml
+│   │   ├── service.yaml
+│   │   └── hpa.yaml
+│   ├── auth-service/
+│   │   ├── deployment.yaml
+│   │   └── service.yaml
+│   ├── postgres/
+│   │   ├── statefulset.yaml
+│   │   └── service.yaml
+│   └── ingress/
+│       ├── ingress.yaml
+│       └── managed-cert.yaml
+└── overlays/
+    ├── dev/
+    │   └── kustomization.yaml      ← 1 replica, :dev image tag
+    └── prod/
+        └── kustomization.yaml      ← 2 replicas, :latest image tag
+```

--- a/k8s/base/api-service/deployment.yaml
+++ b/k8s/base/api-service/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-service
+  namespace: impulsa-prod
+  labels:
+    app: api-service
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: api-service
+  template:
+    metadata:
+      labels:
+        app: api-service
+    spec:
+      containers:
+        - name: api-service
+          image: REGISTRY/impulsa-api:latest
+          ports:
+            - containerPort: 8080
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: NODE_ENV
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: POSTGRES_PORT
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: POSTGRES_DB
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_HOST
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_PASSWORD
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: JWT_SECRET
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3

--- a/k8s/base/api-service/hpa.yaml
+++ b/k8s/base/api-service/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-service-hpa
+  namespace: impulsa-prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-service
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/base/api-service/service.yaml
+++ b/k8s/base/api-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-service
+  namespace: impulsa-prod
+  labels:
+    app: api-service
+spec:
+  type: ClusterIP
+  selector:
+    app: api-service
+  ports:
+    - name: http
+      port: 8080
+      targetPort: 8080

--- a/k8s/base/auth-service/deployment.yaml
+++ b/k8s/base/auth-service/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: auth-service
+  namespace: impulsa-prod
+  labels:
+    app: auth-service
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: auth-service
+  template:
+    metadata:
+      labels:
+        app: auth-service
+    spec:
+      containers:
+        - name: auth-service
+          image: REGISTRY/impulsa-auth:latest
+          ports:
+            - containerPort: 8081
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: NODE_ENV
+            - name: POSTGRES_PORT
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: POSTGRES_PORT
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: POSTGRES_DB
+            - name: POSTGRES_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_HOST
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_PASSWORD
+            - name: JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: JWT_SECRET
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "128Mi"
+            limits:
+              cpu: "300m"
+              memory: "256Mi"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 8081
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3

--- a/k8s/base/auth-service/service.yaml
+++ b/k8s/base/auth-service/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: auth-service
+  namespace: impulsa-prod
+  labels:
+    app: auth-service
+spec:
+  type: ClusterIP
+  selector:
+    app: auth-service
+  ports:
+    - name: http
+      port: 8081
+      targetPort: 8081

--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: impulsa-config
+  namespace: impulsa-prod
+data:
+  NODE_ENV: "production"
+  API_SERVICE_URL: "http://api-service:8080"
+  AUTH_SERVICE_URL: "http://auth-service:8081"
+  # Non-sensitive DB config — host injected per environment overlay
+  POSTGRES_PORT: "5432"
+  POSTGRES_DB: "impulsaedu"

--- a/k8s/base/frontend/deployment.yaml
+++ b/k8s/base/frontend/deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  namespace: impulsa-prod
+  labels:
+    app: frontend
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: REGISTRY/impulsa-frontend:latest
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NODE_ENV
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: NODE_ENV
+            - name: NEXT_PUBLIC_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: API_SERVICE_URL
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 20
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: 3000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3

--- a/k8s/base/frontend/hpa.yaml
+++ b/k8s/base/frontend/hpa.yaml
@@ -1,0 +1,19 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: frontend-hpa
+  namespace: impulsa-prod
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: frontend
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/base/frontend/service.yaml
+++ b/k8s/base/frontend/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: frontend
+  namespace: impulsa-prod
+  labels:
+    app: frontend
+spec:
+  type: ClusterIP
+  selector:
+    app: frontend
+  ports:
+    - name: http
+      port: 80
+      targetPort: 3000

--- a/k8s/base/ingress/ingress.yaml
+++ b/k8s/base/ingress/ingress.yaml
@@ -1,0 +1,41 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: impulsa-ingress
+  namespace: impulsa-prod
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    # GKE managed certificate — set the domain in the overlay
+    networking.gke.io/managed-certificates: "impulsa-cert"
+    nginx.ingress.kubernetes.io/proxy-body-size: "10m"
+spec:
+  tls:
+    - hosts:
+        - REPLACE_WITH_DOMAIN
+      secretName: impulsa-tls
+  rules:
+    - host: REPLACE_WITH_DOMAIN
+      http:
+        paths:
+          - path: /auth
+            pathType: Prefix
+            backend:
+              service:
+                name: auth-service
+                port:
+                  number: 8081
+          - path: /api
+            pathType: Prefix
+            backend:
+              service:
+                name: api-service
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: frontend
+                port:
+                  number: 80

--- a/k8s/base/ingress/managed-cert.yaml
+++ b/k8s/base/ingress/managed-cert.yaml
@@ -1,0 +1,9 @@
+# GKE Managed Certificate — replace domain per overlay
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: impulsa-cert
+  namespace: impulsa-prod
+spec:
+  domains:
+    - REPLACE_WITH_DOMAIN

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - frontend/deployment.yaml
+  - frontend/service.yaml
+  - frontend/hpa.yaml
+  - api-service/deployment.yaml
+  - api-service/service.yaml
+  - api-service/hpa.yaml
+  - auth-service/deployment.yaml
+  - auth-service/service.yaml
+  - postgres/statefulset.yaml
+  - postgres/service.yaml
+  - ingress/ingress.yaml
+  - ingress/managed-cert.yaml

--- a/k8s/base/namespace.yaml
+++ b/k8s/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: impulsa-prod
+  labels:
+    app.kubernetes.io/managed-by: kustomize

--- a/k8s/base/postgres/service.yaml
+++ b/k8s/base/postgres/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: impulsa-prod
+  labels:
+    app: postgres
+spec:
+  type: ClusterIP
+  clusterIP: None   # Headless service for StatefulSet DNS
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: 5432

--- a/k8s/base/postgres/statefulset.yaml
+++ b/k8s/base/postgres/statefulset.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: impulsa-prod
+  labels:
+    app: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16-alpine
+          ports:
+            - containerPort: 5432
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: POSTGRES_DB
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_USER
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: impulsa-secrets
+                  key: POSTGRES_PASSWORD
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+          resources:
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 30
+            periodSeconds: 15
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: standard-rwo
+        resources:
+          requests:
+            storage: 10Gi

--- a/k8s/base/secrets.template.yaml
+++ b/k8s/base/secrets.template.yaml
@@ -1,0 +1,21 @@
+# DO NOT commit real values. This file is a template only.
+# Create the actual Secret with:
+#   kubectl create secret generic impulsa-secrets \
+#     --from-literal=POSTGRES_USER=<user> \
+#     --from-literal=POSTGRES_PASSWORD=<password> \
+#     --from-literal=JWT_SECRET=<secret> \
+#     --namespace=<namespace>
+#
+# For production, use GCP Secret Manager + External Secrets Operator, or SOPS-encrypted SealedSecrets.
+#
+apiVersion: v1
+kind: Secret
+metadata:
+  name: impulsa-secrets
+  namespace: impulsa-prod
+type: Opaque
+stringData:
+  POSTGRES_USER: "REPLACE_ME"
+  POSTGRES_PASSWORD: "REPLACE_ME"
+  JWT_SECRET: "REPLACE_ME"
+  POSTGRES_HOST: "REPLACE_ME"   # Cloud SQL private IP or postgres Service name

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: impulsa-dev
+
+resources:
+  - ../../base
+
+namePrefix: ""
+
+patches:
+  - patch: |-
+      - op: replace
+        path: /spec/replicas
+        value: 1
+    target:
+      kind: Deployment
+  - patch: |-
+      - op: replace
+        path: /spec/minReplicas
+        value: 1
+    target:
+      kind: HorizontalPodAutoscaler
+
+images:
+  - name: REGISTRY/impulsa-frontend
+    newTag: dev
+  - name: REGISTRY/impulsa-api
+    newTag: dev
+  - name: REGISTRY/impulsa-auth
+    newTag: dev
+
+configMapGenerator:
+  - name: impulsa-config
+    behavior: merge
+    literals:
+      - NODE_ENV=development
+      - POSTGRES_HOST=postgres.impulsa-dev.svc.cluster.local

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -1,0 +1,23 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: impulsa-prod
+
+resources:
+  - ../../base
+
+images:
+  - name: REGISTRY/impulsa-frontend
+    newTag: latest
+  - name: REGISTRY/impulsa-api
+    newTag: latest
+  - name: REGISTRY/impulsa-auth
+    newTag: latest
+
+configMapGenerator:
+  - name: impulsa-config
+    behavior: merge
+    literals:
+      - NODE_ENV=production
+      # Set POSTGRES_HOST to Cloud SQL private IP or postgres headless service
+      - POSTGRES_HOST=postgres.impulsa-prod.svc.cluster.local


### PR DESCRIPTION
## Summary

Implements the minimum production-ready GKE architecture for ImpulsaEdu as described in issue #1.

## Changes

### Kubernetes Manifests (`k8s/`)
- **Base layer** (Kustomize): Deployments, Services, and HPAs for `frontend`, `api-service`, and `auth-service`; PostgreSQL StatefulSet with 10Gi PVC; NGINX Ingress with GKE Managed Certificate (TLS); ConfigMap and Secrets template
- **Overlays**: `dev` (impulsa-dev namespace, 1 replica, :dev image tag) and `prod` (impulsa-prod namespace, 2 replicas, :latest image tag)

### CI/CD (`.github/workflows/deploy-gke.yml`)
- Builds and pushes images to Artifact Registry on push to `develop` or `main`
- Deploys via `kustomize build | kubectl apply` using Workload Identity Federation (no long-lived credentials)
- Waits for rollout completion before marking the job successful

### Documentation (`docs/architecture/gke-infrastructure.md`)
- Architecture diagram, node pool sizing, resource limits table, TLS and Secrets strategy, CI/CD flow, and directory structure reference

## Acceptance Criteria (from issue)
- [x] Kubernetes manifests (kustomize) that deploy all 4 services
- [x] TLS-enabled ingress with health/readiness probes configured
- [x] Resource limits and recommended node sizing documented

Closes #1