### PR TITLE
Add PostgreSQL schema DDL

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,168 @@
+-- Extensions
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+-- ENUMS
+CREATE TYPE user_role AS ENUM ('staff', 'admin');
+CREATE TYPE donor_type AS ENUM ('Fisica', 'Moral');
+CREATE TYPE donation_status AS ENUM ('Registrado','Aprobado','Entregando','Entregado','Finalizado','Cancelado');
+CREATE TYPE donation_type AS ENUM ('Material','Monetaria');
+CREATE TYPE school_level AS ENUM ('Preescolar','Primaria','Secundaria','Preparatoria','Universidad');
+CREATE TYPE school_mode AS ENUM ('Presencial','Semi-presencial','En linea');
+CREATE TYPE school_shift AS ENUM ('Matutino','Vespertino','Mixto');
+CREATE TYPE school_category AS ENUM ('Estatal','Federal','Federalizado');
+CREATE TYPE entity_type AS ENUM ('donor','donation','school');
+CREATE TYPE audit_action AS ENUM ('create','update','archive','state_change');
+
+-- USERS
+CREATE TABLE users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  firstname TEXT NOT NULL,
+  middlename TEXT,
+  lastname TEXT NOT NULL,
+  role user_role NOT NULL DEFAULT 'staff',
+  email TEXT NOT NULL UNIQUE,
+  phone TEXT,
+  password_hash TEXT NOT NULL,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id),
+  deleted_at TIMESTAMPTZ,
+  deleted_by UUID REFERENCES users(id)
+);
+
+-- REFRESH TOKENS
+CREATE TABLE refresh_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  token_hash VARCHAR(64) NOT NULL UNIQUE,
+  expires_at TIMESTAMPTZ NOT NULL,
+  revoked BOOLEAN NOT NULL DEFAULT FALSE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- DONORS
+CREATE TABLE donors (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  region TEXT NOT NULL,
+  donor_type donor_type NOT NULL,
+  notes TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id),
+  deleted_at TIMESTAMPTZ,
+  deleted_by UUID REFERENCES users(id),
+
+  UNIQUE(name, region)
+);
+
+-- SCHOOLS
+CREATE TABLE schools (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  region TEXT NOT NULL,
+  school TEXT NOT NULL,
+  name TEXT NOT NULL,
+  employees INT NOT NULL DEFAULT 0,
+  students INT NOT NULL DEFAULT 0,
+  level school_level NOT NULL,
+  cct TEXT NOT NULL,
+  mode school_mode NOT NULL,
+  shift school_shift NOT NULL,
+  address TEXT NOT NULL,
+  location TEXT NOT NULL,
+  category school_category NOT NULL,
+  notes TEXT,
+  goal NUMERIC(12,2) NOT NULL CHECK (goal > 0),
+  progress NUMERIC(12,2) NOT NULL DEFAULT 0 CHECK (progress >= 0),
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id),
+  deleted_at TIMESTAMPTZ,
+  deleted_by UUID REFERENCES users(id),
+
+  UNIQUE(region, school, name)
+);
+
+-- SCHOOL NEEDS
+CREATE TABLE schools_needs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  school_id UUID NOT NULL REFERENCES schools(id),
+  item_name TEXT NOT NULL,
+  quantity INT,
+  unit TEXT,
+  amount NUMERIC(12,2) NOT NULL,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id),
+  deleted_at TIMESTAMPTZ,
+  deleted_by UUID REFERENCES users(id)
+);
+
+-- DONATIONS
+CREATE TABLE donations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  donor_id UUID NOT NULL REFERENCES donors(id),
+  school_id UUID NOT NULL REFERENCES schools(id),
+  amount NUMERIC(12,2) NOT NULL DEFAULT 0,
+  donation_type donation_type NOT NULL,
+  status donation_status NOT NULL DEFAULT 'Registrado',
+  description TEXT,
+  notes TEXT,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id),
+  deleted_at TIMESTAMPTZ,
+  deleted_by UUID REFERENCES users(id)
+);
+
+-- DONATION ITEMS
+CREATE TABLE donation_items (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  donation_id UUID NOT NULL REFERENCES donations(id) ON DELETE CASCADE,
+  item_name TEXT NOT NULL,
+  quantity INT CHECK (quantity > 0),
+  amount NUMERIC(12,2) NOT NULL,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  created_by UUID REFERENCES users(id),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by UUID REFERENCES users(id),
+  deleted_at TIMESTAMPTZ,
+  deleted_by UUID REFERENCES users(id)
+);
+
+-- CONTACTS
+CREATE TABLE contacts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  donor_id UUID REFERENCES donors(id) ON DELETE CASCADE,
+  school_id UUID REFERENCES schools(id) ON DELETE CASCADE,
+  email TEXT,
+  phone TEXT,
+
+  CONSTRAINT chk_contact_owner CHECK (
+    (donor_id IS NOT NULL AND school_id IS NULL) OR
+    (donor_id IS NULL AND school_id IS NOT NULL)
+  )
+);
+
+-- AUDIT LOGS
+CREATE TABLE audit_logs (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  entity_type entity_type NOT NULL,
+  entity_id UUID NOT NULL,
+  action audit_action NOT NULL,
+  old_value JSONB,
+  new_value JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);


### PR DESCRIPTION
Adds production-ready SQL DDL for PostgreSQL based on the canonical schema.
Includes tables, enums, constraints, and relationships.