### PR TITLE
bugfix(k8s): inject NEXT_PUBLIC_APP_API_URL and NEXT_PUBLIC_AUTH_API_UR…

### DIFF
--- a/k8s/base/configmap.yaml
+++ b/k8s/base/configmap.yaml
@@ -12,3 +12,5 @@ data:
   AUTH_PORT: "8081"
   DB_SSL: "false"
   APP_DOMAIN: "impulsaedu.sytes.net"
+  NEXT_PUBLIC_APP_API_URL: "http://api-service.impulsa.svc.cluster.local:8080"
+  NEXT_PUBLIC_AUTH_API_URL: "http://auth-service.impulsa.svc.cluster.local:8081"

--- a/k8s/base/frontend/deployment.yaml
+++ b/k8s/base/frontend/deployment.yaml
@@ -31,6 +31,16 @@ spec:
               value: "/api/v1"
             - name: NEXT_PUBLIC_AUTH_URL
               value: "/auth"
+            - name: NEXT_PUBLIC_APP_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: NEXT_PUBLIC_APP_API_URL
+            - name: NEXT_PUBLIC_AUTH_API_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: impulsa-config
+                  key: NEXT_PUBLIC_AUTH_API_URL
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
…L into frontend

<!-- 
Thank you for contributing to ImpulsaEdu! 

Please fill out all sections below to ensure a smooth review process.
Delete any sections that don't apply to your PR.
-->

## Issue Reference

Closes #67

## Description

Add the two missing env vars to the ConfigMap using Kubernetes internal service DNS FQDNs, then reference them in the frontend Deployment via configMapKeyRef so every frontend pod receives the correct backend URLs without any manual steps.
